### PR TITLE
Use tilde(`~`) to resemble home paths

### DIFF
--- a/lua/bookmarks/utils.lua
+++ b/lua/bookmarks/utils.lua
@@ -6,24 +6,27 @@ end
 local function trim(str)
 	return str:gsub("^%s+", ""):gsub("%s+$", "")
 end
--- Function to shorten a file path
+
+---@param file_path string
+---@return string
 local function shorten_file_path(file_path)
 	local parts = {}
 
+	file_path = file_path:gsub(vim.fn.expand("$HOME"), "~")
 	for part in string.gmatch(file_path, "[^/]+") do
 		table.insert(parts, part)
 	end
 
-	if #parts > 1 then
-		local filename = table.remove(parts) -- Remove and get the last part (filename)
-		local shorten = vim.tbl_map(function(part)
-			return string.sub(part, 1, 1)
-		end, parts)
-
-		return table.concat(shorten, "/") .. "/" .. filename
-	else
+	if #parts <= 1 then
 		return file_path -- If there's only one part, return the original path
 	end
+
+	local filename = table.remove(parts) -- Remove and get the last part (filename)
+	local shorten = vim.tbl_map(function(part)
+		return string.sub(part, 1, 1)
+	end, parts)
+
+	return table.concat(shorten, "/") .. "/" .. filename
 end
 
 ---@param original any


### PR DESCRIPTION
Thanks for the work on the plugin, @LintaoAmons. It's refreshing to see a bookmark plugin that offers such a well-thought-out set of features.

To achieve an even more expressive result and better path shortening, the changes in this PR substitute the home path with a `~`.

|Current|Updated|
|-|-|
|![Screenshot_20240423_160255](https://github.com/LintaoAmons/bookmarks.nvim/assets/34311583/3f71e069-8958-47ae-a82b-4ce656975b9c)|![Screenshot_20240423_160259](https://github.com/LintaoAmons/bookmarks.nvim/assets/34311583/976d580e-eb0e-4ee6-88ee-ecea463da44c)|
