### PR TITLE
Extend config to allow setting custom icon and highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ return { "LintaoAmons/bookmarks.nvim",
   config = function ()
     require("bookmarks").setup( {
       json_db_path = vim.fs.normalize(vim.fn.stdpath("config") .. "/bookmarks.db.json"),
+      signs = {
+        mark = { icon = "", color = "grey" },
+      },
     })
   end
 }
@@ -49,12 +52,12 @@ return { "LintaoAmons/bookmarks.nvim",
 
 There's two concepts in this plugin: `BookmarkList` and `Bookmark`. You can look into the code to find the structure of those two domain objects
 
-| Command                           | Description                                                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `BookmarksMark`                   | Mark current line into active BookmarkList.                                                                 |
-| `BookmarksGoto`                   | Go to bookmark at current active BookmarkList                                                               |
-| `BookmarksCommands`               | Find and trigger a bookmark command.                                                                        |
-| `BookmarksGotoRecent`             | Go to latest visited/created Bookmark                                                                       |
+| Command               | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `BookmarksMark`       | Mark current line into active BookmarkList.   |
+| `BookmarksGoto`       | Go to bookmark at current active BookmarkList |
+| `BookmarksCommands`   | Find and trigger a bookmark command.          |
+| `BookmarksGotoRecent` | Go to latest visited/created Bookmark         |
 
 <details>
 <summary>Commands we have right now</summary>
@@ -113,7 +116,7 @@ You can contact with me by drop me an email or [telegram](https://t.me/+ssgpiHyY
 - [ ] refactor: extract picker module
 - [ ] Telescope as default picker and will fallback to vim.ui if don't have telescope dependencies
 - [x] telescope enhancement (use specific command instead)
-- [ ] Recent files as bookmarks: record all the buffer the user recently opened and sort by the visited_at 
+- [ ] Recent files as bookmarks: record all the buffer the user recently opened and sort by the visited_at
 - [x] A new command to create bookmark and put it into specific bookmark list (instead current active one)
 - [ ] goto next/prev bookmark in the current buffer
 

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -1,10 +1,10 @@
 ---@class Bookmarks.Config
----@field sign { icon: string, highlight: string }
+---@field signs Signs
 local default_config = {
 	json_db_path = vim.fs.normalize(vim.fn.stdpath("config") .. "/bookmarks.db.json"),
-	sign = {
-		icon = "󰃁",
-		highlight = "BookmarksNvimSign",
+	signs = {
+		mark = { icon = "󰃁", color = "grey" },
+		-- annotation = { icon = "󰆉", color = "grey" }, -- TODO:
 	},
 }
 
@@ -14,8 +14,7 @@ vim.g.bookmarks_config = default_config
 local setup = function(user_config)
 	local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config or default_config, user_config or {})
 		or default_config
-	vim.fn.sign_define(cfg.sign.highlight, { text = cfg.sign.icon, texthl = cfg.sign.highlight })
-	vim.api.nvim_set_hl(0, cfg.sign.highlight, { foreground = "grey" }) -- control the color of the sign
+	require("bookmarks.sign").setup(cfg.signs)
 	vim.g.bookmarks_config = cfg
 end
 

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -1,12 +1,22 @@
+---@class Bookmarks.Config
+---@field sign { icon: string, highlight: string }
 local default_config = {
 	json_db_path = vim.fs.normalize(vim.fn.stdpath("config") .. "/bookmarks.db.json"),
+	sign = {
+		icon = "󰃁",
+		highlight = "BookmarksNvimSign",
+	},
 }
 
 vim.g.bookmarks_config = default_config
 
+---@param user_config? Bookmarks.Config
 local setup = function(user_config)
 	local previous_config = vim.g.bookmarks_config or default_config
-	vim.g.bookmarks_config = vim.tbl_deep_extend("force", previous_config, user_config or {}) or default_config
+	local cfg = vim.tbl_deep_extend("force", previous_config, user_config or {}) or default_config
+	vim.fn.sign_define(cfg.sign.highlight, { text = cfg.sign.icon, texthl = cfg.sign.highlight })
+	vim.api.nvim_set_hl(0, cfg.sign.highlight, { foreground = "grey" }) -- control the color of the sign
+	vim.g.bookmarks_config = cfg
 end
 
 return {

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -12,8 +12,8 @@ vim.g.bookmarks_config = default_config
 
 ---@param user_config? Bookmarks.Config
 local setup = function(user_config)
-	local previous_config = vim.g.bookmarks_config or default_config
-	local cfg = vim.tbl_deep_extend("force", previous_config, user_config or {}) or default_config
+	local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config or default_config, user_config or {})
+		or default_config
 	vim.fn.sign_define(cfg.sign.highlight, { text = cfg.sign.icon, texthl = cfg.sign.highlight })
 	vim.api.nvim_set_hl(0, cfg.sign.highlight, { foreground = "grey" }) -- control the color of the sign
 	vim.g.bookmarks_config = cfg

--- a/lua/bookmarks/sign.lua
+++ b/lua/bookmarks/sign.lua
@@ -1,13 +1,30 @@
 local repo = require("bookmarks.repo")
 local ns_name = "BookmarksNvim"
+local hl_name = "BookmarksNvimSign"
 local ns = vim.api.nvim_create_namespace(ns_name)
+
+---@class Signs
+---@field mark Sign
+-- ---@field annotation Sign -- TODO:
+
+---@class Sign
+---@field icon string
+---@field color ?string
+
+---@param signs Signs
+local function setup(signs)
+	for k, _ in pairs(signs) do
+		vim.fn.sign_define(hl_name, { text = signs[k].icon, texthl = hl_name })
+		vim.api.nvim_set_hl(0, hl_name, { foreground = signs[k].color })
+	end
+end
 
 ---@param line number
 local function place_sign(line, buf_number, desc)
-	vim.fn.sign_place(line, ns_name, vim.g.bookmarks_config.sign.highlight, buf_number, { lnum = line })
+	vim.fn.sign_place(line, ns_name, hl_name, buf_number, { lnum = line })
 	local at_end = -1
 	vim.api.nvim_buf_set_extmark(buf_number, ns, line - 1, at_end, {
-		virt_text = { { "  " .. desc, vim.g.bookmarks_config.sign.highlight } },
+		virt_text = { { "  " .. desc, hl_name } },
 		virt_text_pos = "overlay",
 		hl_mode = "combine",
 	})
@@ -52,6 +69,7 @@ local function bookmark_sign_autocmd()
 end
 
 return {
+	setup = setup,
 	bookmark_sign_autocmd = bookmark_sign_autocmd,
 	refresh_signs = safe_refresh_signs,
 }

--- a/lua/bookmarks/sign.lua
+++ b/lua/bookmarks/sign.lua
@@ -1,18 +1,13 @@
 local repo = require("bookmarks.repo")
 local ns_name = "BookmarksNvim"
-local sign_name = "BookmarksNvimSign"
-local sign_icon = "󰃁"
 local ns = vim.api.nvim_create_namespace(ns_name)
-
-vim.fn.sign_define(sign_name, { text = sign_icon, texthl = sign_name })
-vim.api.nvim_set_hl(0, sign_name, { foreground = "grey" }) -- control the color of the sign
 
 ---@param line number
 local function place_sign(line, buf_number, desc)
-	vim.fn.sign_place(line, ns_name, sign_name, buf_number, { lnum = line })
+	vim.fn.sign_place(line, ns_name, vim.g.bookmarks_config.sign.highlight, buf_number, { lnum = line })
 	local at_end = -1
 	vim.api.nvim_buf_set_extmark(buf_number, ns, line - 1, at_end, {
-		virt_text = { { "  " .. desc, sign_name } },
+		virt_text = { { "  " .. desc, vim.g.bookmarks_config.sign.highlight } },
 		virt_text_pos = "overlay",
 		hl_mode = "combine",
 	})


### PR DESCRIPTION
The PR extends the config and adds type annotations. With the update it will be possible to easily customize the sign via the config. It can also be a base for further extensions.

```lua
require("bookmarks").setup({
	sign = { icon = "" },
})
```