### PR TITLE
Respect user input aborts

### DIFF
--- a/lua/bookmarks/adapter/commands.lua
+++ b/lua/bookmarks/adapter/commands.lua
@@ -16,12 +16,10 @@ local commands = {
 		name = "[List] new",
 		callback = function()
 			vim.ui.input({ prompt = "Enter the name of the new list: " }, function(input)
-				local name
-				if input and vim.trim(input) ~= "" then
-					name = input
-				else
-					name = tostring(os.time())
+				if not input then
+					return
 				end
+				local name = vim.trim(input) ~= "" and input or tostring(os.time())
 				local newlist = api.add_list({ name = name })
 				api.mark({ name = "", list_name = newlist.name })
 			end)
@@ -118,7 +116,9 @@ local commands = {
 		callback = function()
 			picker.pick_bookmark(function(bookmark)
 				vim.ui.input({ prompt = "New name of the bookmark" }, function(input)
-					api.rename_bookmark(bookmark.id, input or "")
+					if input then
+						api.rename_bookmark(bookmark.id, input or "")
+					end
 				end)
 			end)
 		end,

--- a/lua/bookmarks/adapter/init.lua
+++ b/lua/bookmarks/adapter/init.lua
@@ -7,7 +7,9 @@ end
 
 local function mark()
 	vim.ui.input({ prompt = "Enter Bookmark name" }, function(input)
-		require("bookmarks.api").mark({ name = input or "" })
+		if input then
+			require("bookmarks.api").mark({ name = vim.trim(input) })
+		end
 	end)
 end
 

--- a/lua/bookmarks/adapter/vim-ui.lua
+++ b/lua/bookmarks/adapter/vim-ui.lua
@@ -5,8 +5,10 @@ local api = require("bookmarks.api")
 
 local function add_list()
 	vim.ui.input({ prompt = "Enter BookmarkList name" }, function(input)
-		input = input or utils.trim(input)
-		if not input or input == "" then
+		if not input then
+			return
+		end
+		if utils.trim(input) == "" then
 			return vim.notify("Require a valid name")
 		end
 		require("bookmarks.api").add_list({ name = input })


### PR DESCRIPTION
Fixes #12

The callback of `ui.input` returns nil if a users aborts the dialog. This should be respected.

With the changes, the decision to abort an input with e.g., <kbd>Ctrl+c</kbd> (or any keymap a user has set to cancel a `DressinInput` dialog)  will correctly not add a bookmark. Adding an empty bookmark will still be possible when hitting <kbd>Enter</kbd> in the empty input dialog as it is not registered as abort.