### PR TITLE
isolate the db file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ return {
   },
   config = function()
     local opts = {
-      -- where you want to put your bookmarks db file (a simple readable json file, which you can edit manually as well, dont forget run `BookmarksReload` command to clean the cache)
+      -- where you want to put your bookmarks db file (a simple readable json file, which you can edit manually as well)
       json_db_path = vim.fs.normalize(vim.fn.stdpath("config") .. "/bookmarks.db.json"),
       -- This is how the sign looks.
       signs = {
@@ -115,8 +115,7 @@ You can look into the code to find the structure of those two domain objects
 | `BookmarksGoto`         | Go to bookmark at current active BookmarkList                                                                                       |
 | `BookmarksCommands`     | Find and trigger a bookmark command.                                                                                                |
 | `BookmarksGotoRecent`   | Go to latest visited/created Bookmark                                                                                               |
-| `BookmarksReload`       | Clean the cache and resync the bookmarks jsonfile                                                                                   |
-| `BookmarksEditJsonFile` | An shortcut to edit bookmark jsonfile, remember BookmarksReload to clean the cache after you finish editing                         |
+| `BookmarksEditJsonFile` | An shortcut to edit bookmark jsonfile                                                                                               |
 | `BookmarksTree`         | Display all bookmarks with tree-view, and use "cut", "paste", "create folder" to edit the tree.                                     |
 
 <details>

--- a/lua/bookmarks/api.lua
+++ b/lua/bookmarks/api.lua
@@ -194,7 +194,7 @@ end
 
 ---@param root_dir string
 local function reset_new_db_path(root_dir)
-  local dir = vim.fn.stdpath('data') .. "/bookmarks/"
+  local dir = vim.fn.stdpath("data") .. "/bookmarks/"
   root_dir = percent_encode(root_dir)
   root_dir = string.format("%s.db.json", root_dir)
   local db_path = dir .. root_dir

--- a/lua/bookmarks/api.lua
+++ b/lua/bookmarks/api.lua
@@ -217,7 +217,6 @@ return {
   add_recent = add_recent,
   find_existing_bookmark_under_cursor = find_existing_bookmark_under_cursor,
   helper = {
-    reload_bookmarks = reload_bookmarks,
     open_bookmarks_jsonfile = open_bookmarks_jsonfile,
   },
 

--- a/lua/bookmarks/api.lua
+++ b/lua/bookmarks/api.lua
@@ -167,10 +167,6 @@ local function find_existing_bookmark_under_cursor()
   return domain.bookmark_list.find_bookmark_by_location(bookmark_list, domain.location.get_current_location())
 end
 
-local function reload_bookmarks()
-  vim.g.bookmarks_cache = nil
-end
-
 local function open_bookmarks_jsonfile()
   vim.cmd("e " .. vim.g.bookmarks_config.json_db_path)
 end

--- a/lua/bookmarks/api.lua
+++ b/lua/bookmarks/api.lua
@@ -175,10 +175,42 @@ local function open_bookmarks_jsonfile()
   vim.cmd("e " .. vim.g.bookmarks_config.json_db_path)
 end
 
+---@param c string The single character to convert
+---@return string The hex representation of that character
+local function char_to_hex(c)
+  return string.format("%%%02X", string.byte(c))
+end
+
+---@param str string The string to encode
+---@return string The percent encoded string
+local function percent_encode(str)
+  if str == nil then
+    return ""
+  end
+  str = str:gsub("\n", "\r\n")
+
+  return (str:gsub("([/\\:*?\"'<>+ |%.%%])", char_to_hex))
+end
+
+---@param root_dir string
+local function reset_new_db_path(root_dir)
+  local dir = vim.fn.stdpath('data') .. "/bookmarks/"
+  root_dir = percent_encode(root_dir)
+  root_dir = string.format("%s.db.json", root_dir)
+  local db_path = dir .. root_dir
+  if vim.fn.isdirectory(dir) == 0 then
+    vim.fn.mkdir(dir, "p")
+  end
+
+  repo.db.reset(db_path)
+  sign.refresh_signs()
+  sign.refresh_tree()
+end
+
 return {
   mark = mark,
   rename_bookmark = rename_bookmark,
-
+  reset_new_db_path = reset_new_db_path,
   add_list = add_list,
   set_active_list = set_active_list,
   rename_bookmark_list = rename_bookmark_list,

--- a/lua/bookmarks/repo.lua
+++ b/lua/bookmarks/repo.lua
@@ -8,7 +8,6 @@ local utils = require("bookmarks.utils")
 
 ---@return Bookmarks.DB
 local get_db = function()
-
   local ok, result =
     pcall(json.read_or_init_json_file, vim.g.bookmarks_config.json_db_path, { projects = {}, bookmark_lists = {} })
 

--- a/lua/bookmarks/repo.lua
+++ b/lua/bookmarks/repo.lua
@@ -8,9 +8,6 @@ local utils = require("bookmarks.utils")
 
 ---@return Bookmarks.DB
 local get_db = function()
-  if vim.g.bookmarks_cache then
-    return vim.g.bookmarks_cache
-  end
 
   local ok, result =
     pcall(json.read_or_init_json_file, vim.g.bookmarks_config.json_db_path, { projects = {}, bookmark_lists = {} })
@@ -23,15 +20,12 @@ local get_db = function()
     )
   end
 
-  vim.g.bookmarks_cache = result
-
   return result
 end
 
 local reset_db = function(db_path)
   local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config, { json_db_path = db_path })
   vim.g.bookmarks_config = cfg
-  vim.g.bookmarks_cache = nil
   get_db()
 end
 
@@ -44,7 +38,6 @@ local save_db = function(domain)
     vim.g.bookmarks_config = current_config
   end
 
-  vim.g.bookmarks_cache = domain
   json.write_json_file(domain, vim.g.bookmarks_config.json_db_path)
 end
 

--- a/lua/bookmarks/repo.lua
+++ b/lua/bookmarks/repo.lua
@@ -29,7 +29,7 @@ local get_db = function()
 end
 
 local reset_db = function(db_path)
-  local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config, {json_db_path = db_path})
+  local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config, { json_db_path = db_path })
   vim.g.bookmarks_config = cfg
   vim.g.bookmarks_cache = nil
   get_db()

--- a/lua/bookmarks/repo.lua
+++ b/lua/bookmarks/repo.lua
@@ -28,6 +28,13 @@ local get_db = function()
   return result
 end
 
+local reset_db = function(db_path)
+  local cfg = vim.tbl_deep_extend("force", vim.g.bookmarks_config, {json_db_path = db_path})
+  vim.g.bookmarks_config = cfg
+  vim.g.bookmarks_cache = nil
+  get_db()
+end
+
 ---@param domain Bookmarks.DB
 local save_db = function(domain)
   local current_config = vim.deepcopy(vim.g.bookmarks_config)
@@ -248,6 +255,7 @@ end
 return {
   db = {
     get = get_db,
+    reset = reset_db,
   },
   bookmark_list = {
     read = {

--- a/lua/bookmarks/sign.lua
+++ b/lua/bookmarks/sign.lua
@@ -106,6 +106,10 @@ local function refresh_tree()
     return
   end
 
+  if not vim.api.nvim_buf_is_valid(ctx.buf) then
+    return
+  end
+
   clean_tree_cache(ctx.buf)
 
   local bookmark_lists = repo.bookmark_list.read.find_all()

--- a/plugin/bookmarks.lua
+++ b/plugin/bookmarks.lua
@@ -37,11 +37,6 @@ vim.api.nvim_create_user_command(
   api.goto_last_visited_bookmark,
   { desc = "Go to latest visited/created Bookmark" }
 )
-vim.api.nvim_create_user_command(
-  "BookmarksReload",
-  api.helper.reload_bookmarks,
-  { desc = "Clean the cache and resync the bookmarks jsonfile" }
-)
 vim.api.nvim_create_user_command("BookmarksEditJsonFile", api.helper.open_bookmarks_jsonfile, {
   desc = "An shortcut to edit bookmark jsonfile, remember BookmarksReload to clean the cache after you finish editing",
 })


### PR DESCRIPTION
For now, if I open multiple nvim and with different session, if I save bookmark, the db file will cover each other that leading to conflicts.
So add API to reset the db file path.
for example in my nvim lua to open different json db for different session.
```
local function restore_bookmark()
  local cwd = vim.fn.getcwd()
  require('bookmarks').api.reset_new_db_path(cwd)
end


local opts = {
  post_restore_cmds = { restore_bookmark },
}

require('auto-session').setup(opts)
```

