### PR TITLE
feat: Add option to allow user formatting of virt_text for bookmark

### DIFF
--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -8,6 +8,9 @@ local default_config = {
   -- This is how the sign looks.
   signs = {
     mark = { icon = "󰃁", color = "red", line_bg = "#572626" },
+    desc_format = function(desc)
+      return desc
+    end,
   },
   picker = {
     -- choose built-in sort logic by name: string, find all the sort logics in `bookmarks.adapter.sort-logic`

--- a/lua/bookmarks/sign.lua
+++ b/lua/bookmarks/sign.lua
@@ -7,6 +7,7 @@ local ns = vim.api.nvim_create_namespace(ns_name)
 
 ---@class Signs
 ---@field mark Sign
+---@field desc_format function(string):string
 -- ---@field annotation Sign -- TODO:
 
 ---@class Sign
@@ -16,14 +17,13 @@ local ns = vim.api.nvim_create_namespace(ns_name)
 
 ---@param signs Signs
 local function setup(signs)
-  for k, _ in pairs(signs) do
-    vim.fn.sign_define(hl_name, { text = signs[k].icon, texthl = hl_name })
-    if signs[k].color then
-      vim.api.nvim_set_hl(0, hl_name, { foreground = signs[k].color })
-    end
-    if signs[k].line_bg then
-      vim.api.nvim_set_hl(0, hl_name_line, { bg = signs[k].line_bg })
-    end
+  local mark = signs.mark
+  vim.fn.sign_define(hl_name, { text = mark.icon, texthl = hl_name })
+  if mark.color then
+    vim.api.nvim_set_hl(0, hl_name, { foreground = mark.color })
+  end
+  if mark.line_bg then
+    vim.api.nvim_set_hl(0, hl_name_line, { bg = mark.line_bg })
   end
 end
 
@@ -74,7 +74,8 @@ local function _refresh_signs(bookmarks)
   for _, bookmark in ipairs(bookmarks) do
     local filepath = vim.fn.expand("%:p")
     if filepath == bookmark.location.path then
-      pcall(place_sign, bookmark.location.line, buf_number, bookmark.name)
+      local desc = vim.g.bookmarks_config.signs.desc_format(bookmark.name)
+      pcall(place_sign, bookmark.location.line, buf_number, desc)
     end
   end
 end


### PR DESCRIPTION
This PR allows customizing what the `virt_text` for a bookmark looks like.

For example, I show an icon in the text, but not in the signs-column:

![image](https://github.com/user-attachments/assets/c1e4239c-64d5-4d3a-847a-1c94f75dfa9c)

Great plugin, thanks! :)