### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ return {
   "LintaoAmons/bookmarks.nvim",
   -- recommand, pin the plugin at specific version for stability
   -- backup your db.json file when you want to upgrade the plugin
-  tag = "v2.2.0",
+  tag = "v2.3.0",
   dependencies = {
     {"kkharji/sqlite.lua"},
     {"nvim-telescope/telescope.nvim"},


### PR DESCRIPTION
Change to use 2.3.0 in installation example. We should find some way to allow user to always grab latest version somehow. I'm not sure how Lazy works in this regard (i.e. lock to major version 2 and highest minor versions like 2.*.*?)
I'm just worried users who might go fast and just copy-paste the installation example will be missing out on new releases :stuck_out_tongue_closed_eyes: 